### PR TITLE
Add missing sensor description field, make sensor ID field required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ tmp
 
 # vim
 .ropeproject
+static/fonts/

--- a/webapp/personal/forms.py
+++ b/webapp/personal/forms.py
@@ -168,7 +168,7 @@ class SensorSettingsForm(FlaskForm):
 
 class SensorRegisterForm(SensorSettingsForm):
     sensor_id = StringField(
-        _('Sensor ID'),
+        _('Sensor ID'), [validators.InputRequired()],
         description=_('The numeric part of the sensorname only')
     )
     sensor_board = SelectField(

--- a/webapp/templates/sensor-settings-form.html
+++ b/webapp/templates/sensor-settings-form.html
@@ -24,7 +24,7 @@
 {{ render_field(location.industry_in_area) }}
 {{ render_field(location.oven_in_area) }}
 {{ render_field(location.traffic_in_area) }}
-
+{{ render_field(form.description) }}
 <h2>{{ _('Hardware configuration') }}</h2>
 {% for sensor in form.sensors %}
   <div class="row">


### PR DESCRIPTION
As discussed with @ohheyitsdave, somehow we missed sensor location description field in the process.

Sensor ID field in initial registration should be required as well.