### PR TITLE
initdb: Add missing test user #17

### DIFF
--- a/initdb/00-external-init.sql
+++ b/initdb/00-external-init.sql
@@ -33,7 +33,8 @@ DELETE FROM `auth_user`;
 INSERT INTO `auth_user` (`id`, `password`, `last_login`, `is_superuser`, `username`, `first_name`, `last_name`, `email`, `is_staff`, `is_active`, `date_joined`) VALUES
 	(1, '...', '2017-04-25 17:37:19', 1, 'admin', '', '', 'test1@codefor.de', 1, 1, '2015-03-31 20:50:35'),
 	(2, '...', '2017-04-25 17:37:19', 1, 'admin2', '', '', 'test2@codefor.de', 1, 1, '2015-03-31 20:50:35'),
-	(3, '...', '2017-04-25 17:37:19', 1, 'admin3', '', '', 'test3@codefor.de', 1, 1, '2015-03-31 20:50:35');
+	(3, '...', '2017-04-25 17:37:19', 1, 'admin3', '', '', 'test3@codefor.de', 1, 1, '2015-03-31 20:50:35'),
+	(17, '...', '2017-04-25 17:37:19', 1, 'webapp', '', '', 'webapp@codefor.de', 1, 1, '2015-03-31 20:50:35');
 /*!40000 ALTER TABLE `auth_user` ENABLE KEYS */;
 
 -- Dumping structure for table feinstaub.sensors_sensortype


### PR DESCRIPTION
SENSOR_DEFAULT_OWNER got changed to 17, but user with that ID was
missing from test external database dump, thus database constraint
failed in development environment.