### PR TITLE
Remove overview-dashboard from navbar, redirect to sensor list after login

### DIFF
--- a/webapp/default_settings.py
+++ b/webapp/default_settings.py
@@ -50,6 +50,8 @@ SECURITY_RECOVERABLE = True
 
 SECURITY_I18N_DIRNAME = os.path.join(PROJECT_ROOT, '..', 'translations')
 
+SECURITY_POST_LOGIN_VIEW = 'personal.sensor_list'
+
 # Docker defaults
 SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://devel:devel@mysql/devel'
 SQLALCHEMY_BINDS = {

--- a/webapp/templates/layout.html
+++ b/webapp/templates/layout.html
@@ -45,7 +45,6 @@
                     {{ navbar_link('frontend.index', _('Home')) }}
 
                     {% if current_user.is_authenticated  %}
-                        {{ navbar_link('personal.dashboard', _('Overview')) }}
                         {{ navbar_link('personal.sensor_list', _('My sensors')) }}
                         {{ navbar_link('users.settings', _('Settings')) }}
                         {{ navbar_link('security.change_password', _('Password change')) }}


### PR DESCRIPTION
As per suggestion from @DeeKey, overview dashboard just duplicates all navbar links. Actual dashboard handler to be removed later.