### PR TITLE
Use flask_babelex instead of flask_babel

### DIFF
--- a/webapp/personal/views.py
+++ b/webapp/personal/views.py
@@ -14,7 +14,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 from flask import (Flask, Blueprint, render_template, current_app, flash, url_for, redirect, session)
 from flask_login import current_user, login_required
 from flask_mail import Message
-from flask_babel import lazy_gettext as _
+from flask_babelex import lazy_gettext as _
 import requests
 import dateutil.parser
 from datetime import datetime, timedelta

--- a/webapp/users/forms.py
+++ b/webapp/users/forms.py
@@ -12,7 +12,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 """
 
 from flask_wtf import FlaskForm
-from flask_babel import lazy_gettext as _
+from flask_babelex import lazy_gettext as _
 from wtforms import (BooleanField, TextField, HiddenField, PasswordField, DateTimeField, validators, IntegerField,
                      SubmitField)
 from . import constants
@@ -22,10 +22,10 @@ class EmailForm(FlaskForm):
     email = TextField(_('E-Mail addresse'),
         [
             validators.DataRequired(
-                message=_('Please enter an e-mail address.') 
+                message=_('Please enter an e-mail address.')
             ),
             validators.Email(
-                message=_('Please enter a correct e-mail address.')  
+                message=_('Please enter a correct e-mail address.')
             )
         ]
     )
@@ -39,14 +39,14 @@ class LoginForm(FlaskForm):
                 message=_('Please enter an e-mail address.')
             ),
             validators.Email(
-                message=_('Please enter a correct e-mail address.') 
+                message=_('Please enter a correct e-mail address.')
             )
         ]
     )
     password = PasswordField(_('Password'),
         [
             validators.DataRequired(
-                message=_('Please enter a password.') 
+                message=_('Please enter a password.')
             )
         ]
     )
@@ -61,14 +61,14 @@ class MinimalRegisterForm(FlaskForm):
                 message=_('Please enter an e-mail address.')
             ),
             validators.Email(
-                message=_('Please enter a correct e-mail address.') 
+                message=_('Please enter a correct e-mail address.')
             )
         ]
     )
     privacy = BooleanField(_('I agree to the <a href="/privacy-policy">Privacy policy</a>'),
         [
             validators.DataRequired(
-                message=_('Please agree to the privacy policy.') 
+                message=_('Please agree to the privacy policy.')
             )
         ]
     )
@@ -82,7 +82,7 @@ class RecoverForm(FlaskForm):
                 message=_('Please enter an e-mail address.')
             ),
             validators.Email(
-                message=_('Please enter a correct e-mail address.') 
+                message=_('Please enter a correct e-mail address.')
             )
         ]
     )
@@ -98,14 +98,14 @@ class RecoverSetForm(FlaskForm):
             validators.Length(
                 min=constants.MIN_PASSWORD_LEN,
                 max=constants.MAX_PASSWORD_LEN,
-                message=_('Password must consist of at least %s letters.') % (constants.MIN_PASSWORD_LEN)
+                message=_('Password must consist of at least %s letters.', constants.MIN_PASSWORD_LEN)
             )
         ]
     )
     password_repeat = PasswordField(_('Password (repeat)'),
         [
             validators.DataRequired(
-                message=_('Please enter a password.') 
+                message=_('Please enter a password.')
             ),
             validators.EqualTo('password', message=_('Passwords must be identical.'))
         ]
@@ -127,7 +127,7 @@ class UserPasswordForm(FlaskForm):
             validators.Length(
                 min=constants.MIN_PASSWORD_LEN,
                 max=constants.MAX_PASSWORD_LEN,
-                message=_('Password must consist of at least %s letters.') % (constants.MIN_PASSWORD_LEN)
+                message=_('Password must consist of at least %s letters.', constants.MIN_PASSWORD_LEN)
             )
         ]
     )

--- a/webapp/users/models.py
+++ b/webapp/users/models.py
@@ -13,7 +13,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 from flask import (current_app, render_template)
 from werkzeug import generate_password_hash, check_password_hash
-from flask_babel import lazy_gettext as _
+from flask_babelex import lazy_gettext as _
 
 from flask_security import UserMixin, RoleMixin
 from ..common.helpers import get_current_time

--- a/webapp/users/views.py
+++ b/webapp/users/views.py
@@ -13,7 +13,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 from urllib.parse import quote_plus
 from flask import (Flask, Blueprint, render_template, current_app, request, flash, url_for, redirect, session, abort,
                    jsonify, send_from_directory)
-from flask_babel import lazy_gettext as _
+from flask_babelex import lazy_gettext as _
 from flask_login import login_required, login_user, current_user, logout_user, confirm_login, login_fresh
 from ..extensions import db, mail
 from hashlib import sha256


### PR DESCRIPTION
Mixed use of flask_babel & flask_babelex sadly breaks translations randomly. This PR replaces most uses of `flask_babel` with `flask_babelex` so that everything should work fine now.

Fixes #22 